### PR TITLE
Cancel button tooltip fix

### DIFF
--- a/src/selection.js
+++ b/src/selection.js
@@ -220,7 +220,7 @@
                 element:    this.cancelButton ? $.getElement( this.cancelButton ) : null,
                 clickTimeThreshold: this.viewer.clickTimeThreshold,
                 clickDistThreshold: this.viewer.clickDistThreshold,
-                tooltip:    $.getString('Tooltips.SelectionConfirm') || 'Cancel selection',
+                tooltip:    $.getString('Tooltips.SelectionCancel') || 'Cancel selection',
                 srcRest:    prefix + this.navImages.selectionCancel.REST,
                 srcGroup:   prefix + this.navImages.selectionCancel.GROUP,
                 srcHover:   prefix + this.navImages.selectionCancel.HOVER,


### PR DESCRIPTION
Tooltips.SelectionConfirm applies to confirm button (ok) but also to cancel button (ko).
This patch fixes the bug using Tooltips.SelectionCancel label for cancel button.